### PR TITLE
Méthode manquante

### DIFF
--- a/src/test/java/org/xteam/goldrush/simu/test/PlayerConnectionMock.java
+++ b/src/test/java/org/xteam/goldrush/simu/test/PlayerConnectionMock.java
@@ -34,5 +34,9 @@ public class PlayerConnectionMock implements PlayerConnection {
 	public String getWritten() {
 		return writer.toString();
 	}
+
+    @Override
+    public void stop() {
+    }
 	
 }


### PR DESCRIPTION
La version actuelle ne compile pas puisque PlayerConnectionMock qui implémente PlayerConnection ne possède pas la méthode stop alors qu'elle est requise par PlayerConnection.
